### PR TITLE
Fix `erem` not respecting case-insensitivity

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1092,7 +1092,7 @@ module.exports = grammar({
         optional($._end_line),
         $._nl,
         alias(repeat(seq(repeat(/[^\n]/), $._nl)), $.comment),
-        alias(/\s+erem/, $.control_mnemonic),
+        alias(/\s+erem/i, $.control_mnemonic),
         optional($._end_line)
       ),
 


### PR DESCRIPTION
Self-explanatory; `rem` sequences only look for `erem` but not `EREM` to complete the sequence. Perhaps it'd be better to use `$._erem_mnemonic` here, but I can't for the life of me get it to work, so here is a simple in-place fix.